### PR TITLE
Feat: client side router 설정

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "@typescript-eslint/parser": "^5.48.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.7.0",
     "styled-components": "^5.3.6"
   },
   "devDependencies": {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,30 @@
 import { ReactElement } from 'react';
-import Modal from '@components/Modal';
+import { Routes, Route } from 'react-router-dom';
+import NavBar from '@components/NavBar';
+import ItemsPage from '@pages/ItemsPage';
+import CategoryPage from '@pages/CategoryPage';
+import ProductPage from '@pages/ProductPage';
+import ProductLogPage from '@pages/ProductLogPage';
+import PartsPage from '@pages/PartsPage';
+import PartLogPage from '@pages/PartLogPage';
+import AccountsPage from '@pages/AccountsPage';
+import NotFound from '@pages/NotFound';
 
 function App(): ReactElement {
   return (
     <div className="App">
-      <Modal></Modal>
+      <NavBar />
+      <Routes>
+        <Route path="/" />
+        <Route path="/items" element={<ItemsPage />} />
+        <Route path="/items/:category" element={<CategoryPage />} />
+        <Route path="/items/:category/:product" element={<ProductPage />} />
+        <Route path="/items/:category/:product/log" element={<ProductLogPage />} />
+        <Route path="/parts" element={<PartsPage />} />
+        <Route path="/parts/:part/log" element={<PartLogPage />} />
+        <Route path="/accounts" element={<AccountsPage />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
     </div>
   );
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,11 +9,13 @@ import PartsPage from '@pages/PartsPage';
 import PartLogPage from '@pages/PartLogPage';
 import AccountsPage from '@pages/AccountsPage';
 import NotFound from '@pages/NotFound';
+import Breadcrumb from '@components/Breadcrumb';
 
 function App(): ReactElement {
   return (
     <div className="App">
       <NavBar />
+      <Breadcrumb />
       <Routes>
         <Route path="/" />
         <Route path="/items" element={<ItemsPage />} />

--- a/client/src/components/AccountPage/DeleteButton.tsx
+++ b/client/src/components/AccountPage/DeleteButton.tsx
@@ -1,0 +1,8 @@
+import { ReactElement } from 'react';
+import TextButton from '@components/TextButton';
+
+function DeleteButton(): ReactElement {
+  return <TextButton color="--color-red">삭제</TextButton>;
+}
+
+export default DeleteButton;

--- a/client/src/components/AccountPage/EditButton.tsx
+++ b/client/src/components/AccountPage/EditButton.tsx
@@ -1,0 +1,8 @@
+import { ReactElement } from 'react';
+import TextButton from '@components/TextButton';
+
+function EditButton(): ReactElement {
+  return <TextButton color="--color-blue">수정</TextButton>;
+}
+
+export default EditButton;

--- a/client/src/components/Breadcrumb.tsx
+++ b/client/src/components/Breadcrumb.tsx
@@ -1,28 +1,46 @@
+import { usePathArray } from '@utils/usePathArray';
 import { ReactElement } from 'react';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
-interface Props {
-  color?: string;
-  highlightColor?: string;
-}
-
-const Wrapper = styled.span<Props>`
+const Wrapper = styled.div`
   font-family: 'Noto Sans KR';
-  color: var(${({ color }) => color ?? '--color-gray'});
-  font-size: 18px;
+  color: var(--color-gray);
+  font-size: 28px;
   font-weight: 700;
+  display: flex;
+  gap: 10px;
+  margin: 15px;
 
-  :last-child {
-    color: var(${({ highlightColor }) => highlightColor ?? '--color-blue'});
+  a {
+    text-decoration: none;
+    &:link {
+      color: var(--color-gray);
+    }
+    &:visited {
+      color: var(--color-gray);
+    }
+    &:last-child {
+      color: var(--color-blue);
+    }
   }
 `;
 
-function Breadcrumb({ routes, ...props }: Props & { routes: string[] }): ReactElement {
+function Breadcrumb(): ReactElement {
+  const pathArray = usePathArray();
+
   return (
-    <Wrapper {...props}>
-      {routes.map((route, i) => (
-        <a key={route}>{`${i !== 0 ? '>' : ''} ${route}`}</a>
-      ))}
+    <Wrapper>
+      {pathArray.map((el) => {
+        return (
+          <>
+            <span>{'>'}</span>
+            <Link to={el.path} key={el.path}>
+              <span>{el.lastParam}</span>
+            </Link>
+          </>
+        );
+      })}
     </Wrapper>
   );
 }

--- a/client/src/components/LoginButton.tsx
+++ b/client/src/components/LoginButton.tsx
@@ -10,9 +10,9 @@ const StyledButton = styled.button`
   border: none;
 `;
 
-function LoginButton(): ReactElement {
+function LoginButton({ onClick }: { onClick: () => void }): ReactElement {
   return (
-    <StyledButton>
+    <StyledButton onClick={onClick}>
       <img src={Login} />
     </StyledButton>
   );

--- a/client/src/components/LoginModal.tsx
+++ b/client/src/components/LoginModal.tsx
@@ -2,12 +2,14 @@ import { ReactElement } from 'react';
 import styled from 'styled-components';
 import ModalInput from '@components/ModalInput';
 import Text from '@components/Text';
-import TextButton from '@components/TextButton';
+import TextButton from './TextButton';
 
 const Wrapper = styled.div`
   position: fixed;
   width: 100vw;
   height: 100vh;
+  top: 0;
+  left: 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -37,22 +39,26 @@ const InputWrapper = styled.div`
   box-shadow: 1px 1px 4px 4px var(--color-black);
 `;
 
-const ExitButton = styled(Text)`
+const ExitButton = styled(TextButton)`
   cursor: pointer;
   margin-top: 20px;
+  font-size: 18px;
+  font-weight: 500;
+  border: none;
+  background-color: transparent;
 `;
 
-function Modal(): ReactElement {
+function LoginModal({ onCancel }: { onCancel: () => void }): ReactElement {
   return (
     <Wrapper>
-      <Overlay />
+      <Overlay onClick={onCancel} />
       <InputWrapper>
         <Text size={24} weight={700}>
           로그인
         </Text>
         <ModalInput title="ID" placeholder={'ID를 입력하세요...'}></ModalInput>
         <ModalInput title="Password" placeholder={'비밀번호를 입력하세요...'}></ModalInput>
-        <ExitButton size={18} weight={500} color={'--color-red'}>
+        <ExitButton color={'--color-red'} onClick={onCancel}>
           돌아가기
         </ExitButton>
       </InputWrapper>
@@ -60,4 +66,4 @@ function Modal(): ReactElement {
   );
 }
 
-export default Modal;
+export default LoginModal;

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, useState } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import LoginButton from '@components/LoginButton';
 import NavButton from '@components/NavButton';
@@ -32,9 +33,15 @@ function NavBar(): ReactElement {
   return (
     <Wrapper>
       <Menus>
-        <NavButton selected={selectedPage === 'Products'}>Products</NavButton>
-        <NavButton selected={selectedPage === 'Parts'}>Parts</NavButton>
-        <NavButton selected={selectedPage === 'Accounts'}>Accounts</NavButton>
+        <Link to="/items">
+          <NavButton selected={selectedPage === 'Products'}>Products</NavButton>
+        </Link>
+        <Link to="/parts">
+          <NavButton selected={selectedPage === 'Parts'}>Parts</NavButton>
+        </Link>
+        <Link to="/accounts">
+          <NavButton selected={selectedPage === 'Accounts'}>Accounts</NavButton>
+        </Link>
       </Menus>
       <CenteredSearchInput />
       <LoginButton />

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -34,7 +34,7 @@ function NavBar(): ReactElement {
     <Wrapper>
       <Menus>
         <Link to="/items">
-          <NavButton selected={selectedPage === 'items'}>Products</NavButton>
+          <NavButton selected={selectedPage === 'items'}>Items</NavButton>
         </Link>
         <Link to="/parts">
           <NavButton selected={selectedPage === 'parts'}>Parts</NavButton>

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import LoginButton from '@components/LoginButton';
 import NavButton from '@components/NavButton';
@@ -26,21 +26,21 @@ const CenteredSearchInput = styled(SearchInput)`
   transform: translateX(-50%); */
 `;
 
-type PageTypes = 'Products' | 'Parts' | 'Accounts';
+// type PageTypes = 'Products' | 'Parts' | 'Accounts';
 
 function NavBar(): ReactElement {
-  const [selectedPage] = useState<PageTypes>('Products');
+  const selectedPage = useLocation().pathname.split('/')[1];
   return (
     <Wrapper>
       <Menus>
         <Link to="/items">
-          <NavButton selected={selectedPage === 'Products'}>Products</NavButton>
+          <NavButton selected={selectedPage === 'items'}>Products</NavButton>
         </Link>
         <Link to="/parts">
-          <NavButton selected={selectedPage === 'Parts'}>Parts</NavButton>
+          <NavButton selected={selectedPage === 'parts'}>Parts</NavButton>
         </Link>
         <Link to="/accounts">
-          <NavButton selected={selectedPage === 'Accounts'}>Accounts</NavButton>
+          <NavButton selected={selectedPage === 'accounts'}>Accounts</NavButton>
         </Link>
       </Menus>
       <CenteredSearchInput />

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import LoginButton from '@components/LoginButton';
 import NavButton from '@components/NavButton';
 import SearchInput from '@components/SearchInput';
+import LoginModal from './LoginModal';
 
 const Wrapper = styled.div`
   position: relative;
@@ -30,6 +31,7 @@ const CenteredSearchInput = styled(SearchInput)`
 
 function NavBar(): ReactElement {
   const selectedPage = useLocation().pathname.split('/')[1];
+  const [showModal, setShowModal] = useState<boolean>(false);
   return (
     <Wrapper>
       <Menus>
@@ -44,7 +46,18 @@ function NavBar(): ReactElement {
         </Link>
       </Menus>
       <CenteredSearchInput />
-      <LoginButton />
+      <LoginButton
+        onClick={() => {
+          setShowModal(true);
+        }}
+      />
+      {showModal && (
+        <LoginModal
+          onCancel={() => {
+            setShowModal(false);
+          }}
+        />
+      )}
     </Wrapper>
   );
 }

--- a/client/src/components/NavButton.tsx
+++ b/client/src/components/NavButton.tsx
@@ -15,7 +15,7 @@ const Wrapper = styled.button<StyledProps>`
   padding-block: 30px;
   background-color: transparent;
   border: none;
-  border-bottom: ${({ selected }) => (selected === true ? '4px solid var(--color-blue)' : 'none')};
+  border-bottom: ${({ selected }) => (selected === true ? '4px solid var(--color-blue)' : '4px solid transparent')};
 `;
 
 const StyledText = styled(Text)<StyledProps>`

--- a/client/src/components/Page.tsx
+++ b/client/src/components/Page.tsx
@@ -1,0 +1,8 @@
+import { ReactElement } from 'react';
+import Breadcrumb from './Breadcrumb';
+
+function Page(): ReactElement {
+  return <Breadcrumb />;
+}
+
+export default Page;

--- a/client/src/components/Table.tsx
+++ b/client/src/components/Table.tsx
@@ -1,0 +1,79 @@
+import { ReactElement } from 'react';
+import styled from 'styled-components';
+import EditButton from './AccountPage/EditButton';
+import DeleteButton from './AccountPage/DeleteButton';
+const headers = ['No.', 'ID', '권한', '생성일', '수정일', '수정', '삭제'];
+
+const rows = [
+  {
+    ID: '아이디',
+    권한: '관리자',
+    생성일: new Date().toDateString(),
+    수정일: new Date().toDateString(),
+  },
+  {
+    ID: '아이디',
+    권한: '관리자',
+    생성일: new Date().toDateString(),
+    수정일: new Date().toDateString(),
+  },
+];
+
+const StyledTable = styled.table`
+  width: 100%;
+  thead {
+    background-color: var(--color-blue);
+    color: var(--color-white);
+    th {
+      padding: 5px;
+    }
+  }
+  tbody {
+    background-color: var(--color-white);
+    color: var(--color-black);
+    td {
+      padding: 5px;
+    }
+  }
+`;
+
+function Table(): ReactElement {
+  return (
+    <StyledTable>
+      <thead>
+        <tr>
+          {headers.map((header) => (
+            <th key={header}>{header}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr key={i}>
+            {headers.map((header) => {
+              if (header === 'No.') {
+                return <td key={`${header}${i}`}>{i + 1}</td>;
+              } else if (header === '수정') {
+                return (
+                  <td key={`${header}${i}`}>
+                    <EditButton />
+                  </td>
+                );
+              } else if (header === '삭제') {
+                return (
+                  <td key={`${header}${i}`}>
+                    <DeleteButton />
+                  </td>
+                );
+              } else {
+                return <td key={`${header}${i}`}>{row[header as keyof typeof row]}</td>;
+              }
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </StyledTable>
+  );
+}
+
+export default Table;

--- a/client/src/components/TextButton.tsx
+++ b/client/src/components/TextButton.tsx
@@ -1,10 +1,11 @@
 import { ReactElement } from 'react';
 import styled from 'styled-components';
-import { ReactProps } from '@type/props';
+import { ReactProps, StyledProps } from '@type/props';
 
 interface Props {
   color?: string;
   backgroundColor?: string;
+  onClick?: () => void;
 }
 
 const StyledButton = styled.button<Props>`
@@ -12,13 +13,13 @@ const StyledButton = styled.button<Props>`
   color: var(${({ color }) => color ?? '--color-dark-gray'});
   background-color: var(${({ backgroundColor }) => backgroundColor ?? '--color-lightest-gray'});
   padding-inline: 12px;
-  padding-block: 6px;
-  border-radius: 10px;
+  padding-block: 3px;
+  border-radius: 5px;
   border: 1px solid var(${({ color }) => color ?? '--color-dark-gray'});
   box-sizing: border-box;
 `;
 
-function TextButton({ children, ...props }: ReactProps<Props>): ReactElement {
+function TextButton({ children, ...props }: StyledProps<ReactProps<Props>>): ReactElement {
   return <StyledButton {...props}>{children}</StyledButton>;
 }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -63,3 +63,6 @@ table {
 button {
 	cursor: pointer;
 }
+a {
+	all: unset;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -65,4 +65,5 @@ button {
 }
 a {
 	all: unset;
+	cursor: pointer;
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 );

--- a/client/src/pages/AccountsPage.tsx
+++ b/client/src/pages/AccountsPage.tsx
@@ -1,7 +1,12 @@
+import Table from '@components/Table';
 import { ReactElement } from 'react';
 
 function AccountsPage(): ReactElement {
-  return <div>AccountsPage</div>;
+  return (
+    <div>
+      <Table />
+    </div>
+  );
 }
 
 export default AccountsPage;

--- a/client/src/pages/AccountsPage.tsx
+++ b/client/src/pages/AccountsPage.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+function AccountsPage(): ReactElement {
+  return <div>AccountsPage</div>;
+}
+
+export default AccountsPage;

--- a/client/src/pages/CategoryPage.tsx
+++ b/client/src/pages/CategoryPage.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+function CategoryPage(): ReactElement {
+  return <div>CategoryPage</div>;
+}
+
+export default CategoryPage;

--- a/client/src/pages/ItemsPage.tsx
+++ b/client/src/pages/ItemsPage.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+function ItemsPage(): ReactElement {
+  return <div>ItemsPage</div>;
+}
+
+export default ItemsPage;

--- a/client/src/pages/NotFound.tsx
+++ b/client/src/pages/NotFound.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+function NotFound(): ReactElement {
+  return <div>NotFound</div>;
+}
+
+export default NotFound;

--- a/client/src/pages/PartLogPage.tsx
+++ b/client/src/pages/PartLogPage.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+function PartLogPage(): ReactElement {
+  return <div>PartLogPage</div>;
+}
+
+export default PartLogPage;

--- a/client/src/pages/PartsPage.tsx
+++ b/client/src/pages/PartsPage.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+function PartsPage(): ReactElement {
+  return <div>PartsPage</div>;
+}
+
+export default PartsPage;

--- a/client/src/pages/ProductLogPage.tsx
+++ b/client/src/pages/ProductLogPage.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+function ProductLogPage(): ReactElement {
+  return <div>ProductLogPage</div>;
+}
+
+export default ProductLogPage;

--- a/client/src/pages/ProductPage.tsx
+++ b/client/src/pages/ProductPage.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+function ProductPage(): ReactElement {
+  return <div>ProductPage</div>;
+}
+
+export default ProductPage;

--- a/client/src/utils/usePathArray.ts
+++ b/client/src/utils/usePathArray.ts
@@ -1,0 +1,15 @@
+import { useLocation } from 'react-router-dom';
+
+export interface Path {
+  path: string;
+  lastParam: string;
+}
+
+export const usePathArray = (): Path[] => {
+  const { pathname } = useLocation();
+  const result = pathname
+    .split('/')
+    .slice(1)
+    .map((el, i, arr) => ({ path: arr.filter((el2, j) => j <= i).join('/'), lastParam: el }));
+  return result;
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -21,6 +21,7 @@
       "@pages/*": ["src/pages/*"],
       "@type/*": ["src/types/*"],
       "@images/*": ["src/images/*"],
+      "@utils/*": ["src/utils/*"],
       "@": ["src/*"]
     }
   },

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       '@components': path.resolve(__dirname, './src/components'),
       '@pages': path.resolve(__dirname, './src/pages'),
       '@images': path.resolve(__dirname, './src/images'),
+      '@utils': path.resolve(__dirname, './src/utils'),
     }
   }
 })

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -443,6 +443,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@remix-run/router@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.0.tgz#b6ee542c7f087b73b3d8215b9bf799f648be71cb"
+  integrity sha512-nwQoYb3m4DDpHTeOwpJEuDt8lWVcujhYYSFGLluC+9es2PyLjm+jjq3IeRBQbwBtPLJE/lkuHuGHr8uQLgmJRA==
+
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -2087,6 +2092,21 @@ react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
+react-router-dom@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.7.0.tgz#0249f4ca4eb704562b8b0ff29caeb928c3a6ed38"
+  integrity sha512-jQtXUJyhso3kFw430+0SPCbmCmY1/kJv8iRffGHwHy3CkoomGxeYzMkmeSPYo6Egzh3FKJZRAL22yg5p2tXtfg==
+  dependencies:
+    "@remix-run/router" "1.3.0"
+    react-router "6.7.0"
+
+react-router@6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.7.0.tgz#db262684c13b5c2970694084ae9e8531718a0681"
+  integrity sha512-KNWlG622ddq29MAM159uUsNMdbX8USruoKnwMMQcs/QWZgFUayICSn2oB7reHce1zPj6CG18kfkZIunSSRyGHg==
+  dependencies:
+    "@remix-run/router" "1.3.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
## 개요
client side router 설정

## 세부 내용

`App.tsx`에서 아래와 같이 route를 관리한다.
```
/ : 메인페이지
/items : 카테고리 목록 페이지
/items/:category : 특정 카테고리의 프로덕트 목록 페이지
/items/:category/:product : 특정 프로덕트의 BOM 목록 페이지
/items/:cateogry/:product/log : 특정 프로덕트의 Log 페이지
/parts : 파트 목록 페이지
/parts/:part/log : 특정 파트의 Log 페이지
/accounts : 계정 목록 페이지
```

## 공유
- Router 경로 정리 노션
  https://www.notion.so/Client-Side-Routing-e24efc722d60480a99da094589db3bdd
- 기본적으로 URL에서 얻을 수 있는 데이터는 URL에서 얻어 사용한다.
- 존재하지 않는 API 요청의 예외처리는 별도로 하지 않은 상태임.
- NavBar를 공용으로 사용하고 있으나, 메인 페이지 별도 구성 시 구조 변경이 필요함.
- Router와 무관하나 Table 스타일 수정이 일부 PR에 포함되어 있음.

## 관련 이슈
  #5 
