### PR TITLE
Feat: Main Page 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import PartLogPage from '@pages/PartLogPage';
 import AccountsPage from '@pages/AccountsPage';
 import NotFound from '@pages/NotFound';
 import Breadcrumb from '@components/Breadcrumb';
+import MainPage from '@pages/MainPage';
 
 function App(): ReactElement {
   return (
@@ -17,7 +18,7 @@ function App(): ReactElement {
       <NavBar />
       <Breadcrumb />
       <Routes>
-        <Route path="/" />
+        <Route path="/" element={<MainPage />} />
         <Route path="/items" element={<ItemsPage />} />
         <Route path="/items/:category" element={<CategoryPage />} />
         <Route path="/items/:category/:product" element={<ProductPage />} />

--- a/client/src/components/LoginButton.tsx
+++ b/client/src/components/LoginButton.tsx
@@ -1,20 +1,38 @@
-import { ReactElement } from 'react';
-import styled from 'styled-components';
-import Login from '@images/user.svg';
+import { ReactProps } from '@type/props';
+import { ReactElement, useState } from 'react';
+import { useQueryClient } from 'react-query';
+import { toast } from 'react-toastify';
+import LoginModal from './LoginModal';
 
-const StyledButton = styled.button`
-  background-color: transparent;
-  padding: auto;
-  height: 84px;
-  width: 84px;
-  border: none;
-`;
+function LoginButton({ children }: ReactProps<{}>): ReactElement {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const queryClient = useQueryClient();
 
-function LoginButton({ onClick }: { onClick: () => void }): ReactElement {
+  const handleOnClick = (): void => {
+    if (queryClient.getQueryData('user') === undefined) setShowModal(true);
+    else {
+      toast.success('로그아웃되었습니다.');
+      queryClient.setQueryData('user', undefined);
+    }
+  };
+
   return (
-    <StyledButton onClick={onClick}>
-      <img src={Login} />
-    </StyledButton>
+    <div>
+      <div
+        onClick={() => {
+          handleOnClick();
+        }}
+      >
+        {children}
+      </div>
+      {showModal && (
+        <LoginModal
+          onCancel={() => {
+            setShowModal(false);
+          }}
+        />
+      )}
+    </div>
   );
 }
 

--- a/client/src/components/MainButton.tsx
+++ b/client/src/components/MainButton.tsx
@@ -1,0 +1,31 @@
+import { ReactElement } from 'react';
+import styled from 'styled-components';
+import { ReactProps } from '@type/props';
+import Text from '@components/Text';
+
+interface Props {
+  onClick?: () => void;
+}
+
+const StyledButton = styled.button`
+  font-family: 'Noto Sans KR';
+  color: var(--color-black);
+  background-color: var(--color-lightest-gray);
+  padding-inline: 60px;
+  padding-block: 30px;
+  border-radius: 30px;
+  border: none;
+  box-shadow: 0px 5px 3px 0px var(--color-light-gray);
+`;
+
+function MainButton({ children, ...props }: ReactProps<Props>): ReactElement {
+  return (
+    <StyledButton {...props}>
+      <Text size={30} weight={600}>
+        {children}
+      </Text>
+    </StyledButton>
+  );
+}
+
+export default MainButton;

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -1,12 +1,10 @@
-import { ReactElement, useState } from 'react';
+import { ReactElement } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import LoginButton from '@components/LoginButton';
 import NavButton from '@components/NavButton';
 import SearchInput from '@components/SearchInput';
-import LoginModal from './LoginModal';
-import { useQueryClient } from 'react-query';
-import { toast } from 'react-toastify';
+import UserButton from './UserButton';
 
 const Wrapper = styled.div`
   position: relative;
@@ -33,16 +31,6 @@ const CenteredSearchInput = styled(SearchInput)`
 
 function NavBar(): ReactElement {
   const selectedPage = useLocation().pathname.split('/')[1];
-  const [showModal, setShowModal] = useState<boolean>(false);
-  const queryClient = useQueryClient();
-
-  const handleOnClick = (): void => {
-    if (queryClient.getQueryData('user') === undefined) setShowModal(true);
-    else {
-      toast.success('로그아웃되었습니다.');
-      queryClient.setQueryData('user', undefined);
-    }
-  };
 
   return (
     <Wrapper>
@@ -58,14 +46,9 @@ function NavBar(): ReactElement {
         </Link>
       </Menus>
       <CenteredSearchInput />
-      <LoginButton onClick={handleOnClick} />
-      {showModal && (
-        <LoginModal
-          onCancel={() => {
-            setShowModal(false);
-          }}
-        />
-      )}
+      <LoginButton>
+        <UserButton />
+      </LoginButton>
     </Wrapper>
   );
 }

--- a/client/src/components/UserButton.tsx
+++ b/client/src/components/UserButton.tsx
@@ -1,0 +1,21 @@
+import { ReactElement } from 'react';
+import styled from 'styled-components';
+import User from '@images/user.svg';
+
+const StyledButton = styled.button`
+  background-color: transparent;
+  padding: auto;
+  height: 84px;
+  width: 84px;
+  border: none;
+`;
+
+function UserButton(): ReactElement {
+  return (
+    <StyledButton>
+      <img src={User} />
+    </StyledButton>
+  );
+}
+
+export default UserButton;

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,0 +1,38 @@
+import { ReactElement, useEffect } from 'react';
+import MainButton from '@components/MainButton';
+import Text from '@components/Text';
+import styled from 'styled-components';
+import LoginButton from '@components/LoginButton';
+import { useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+
+const Wrapper = styled.div`
+  height: 50vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  padding: 100px;
+`;
+
+function MainPage(): ReactElement {
+  const queryClient = useQueryClient();
+  const user = queryClient.getQueryData('user');
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (user !== undefined) navigate('/items');
+  }, [user]);
+
+  return (
+    <Wrapper>
+      <Text size={100}>iStock</Text>
+      {user === undefined && (
+        <LoginButton>
+          <MainButton>로그인 하기</MainButton>
+        </LoginButton>
+      )}
+    </Wrapper>
+  );
+}
+
+export default MainPage;


### PR DESCRIPTION
## 개요
<img width="1438" alt="스크린샷 2023-02-08 오전 2 24 52" src="https://user-images.githubusercontent.com/97649363/217318783-1ef1b1d1-e8ce-471f-9e87-08cc398d1875.png">
Main Page 구현

## 세부 내용
- MainButton 컴포넌트 구현
- Login Button 리팩터링
  - NavBar의 로그인 로직을 분리해 컴포넌트로 만들어 Children으로 UI컴포넌트를 삽입하게 수정
  - 기존 LoginButton(UI) -> UserButton으로 명명 수정
- MainPage 구현
  - user가 있다면 items로 navigate, 없다면 MainPage를 보여줌 


## 공유

- 로그인이 되어있다면 '/'로 접속했을시 지금처럼 '/items'로 가게 만들까요, 아니면 MainPage에 '환영합니다, username님'이라고 어떤 유저인지 알려주는게 좋을까요?
  
## 관련 이슈

- #18 