### PR TITLE
[FEAT] modal 추상화 및 account 페이지에 적용

### DIFF
--- a/client/src/components/AuthModal.tsx
+++ b/client/src/components/AuthModal.tsx
@@ -1,86 +1,90 @@
 import useMutate from '@hooks/useMutate';
 import { ReactElement, RefObject, useEffect, useRef, useState } from 'react';
-import { toast } from 'react-toastify';
 
-import ModalInput from './ModalInput';
 import SelectInput from './SelectInput';
+import Modal from './Modal';
+import Text from './Text';
 
 import { createUser, updateUser } from '@utils/useAccounts';
-import Modal from './Modal';
+import useInput from '@hooks/useInput';
+import RequiredInput from './RequiredInput';
 
 interface Props {
   close: () => void;
   target: any;
 }
 
-interface RefType {
-  idInput: RefObject<HTMLInputElement>;
-  passwordInput: RefObject<HTMLInputElement>;
-  roleInput: RefObject<HTMLSelectElement>;
+interface ModalBodyProps {
+  isUpdate: boolean;
+  id: string;
+  onChangeId: Function;
+  isValidId: boolean;
+  password: string;
+  onChangePassword: Function;
+  isValidPassword: boolean;
+  roleNameRef: RefObject<HTMLSelectElement>;
 }
-// type HtmlElement = HTMLInputElement | HTMLSelectElement;
-
-const validationCheck = (refObj: RefType): boolean => {
-  const mappedArr = Object.keys(refObj).map((x) => refObj[x as keyof RefType].current?.value);
-  if (mappedArr.some((x) => x === '')) {
-    toast.error('모든 필드를 입력하세요.');
-    return false;
-  }
-  return true;
-};
 
 const ROLES = ['ROLE_ADMIN', 'ROLE_USER'];
 
+function ModalBody({
+  isUpdate,
+  id,
+  onChangeId,
+  isValidId,
+  password,
+  onChangePassword,
+  isValidPassword,
+  roleNameRef,
+}: ModalBodyProps): ReactElement {
+  return (
+    <>
+      <Text size={24}>{isUpdate ? '계정 수정' : '계정 생성'}</Text>
+      <RequiredInput value={id} title="ID" onChange={onChangeId} isValid={isValidId} readonly={isUpdate} />
+      {!isUpdate && (
+        <RequiredInput value={password} title="비밀번호" onChange={onChangePassword} isValid={isValidPassword} />
+      )}
+      <SelectInput optionList={ROLES} title="권한" ref={roleNameRef} />
+    </>
+  );
+}
+
 function AuthModal({ close, target }: Props): ReactElement {
+  const createMutate = useMutate({ key: 'users', action: createUser, onSuccess: close });
+  const updateMutate = useMutate({ key: 'users', action: updateUser, onSuccess: close });
+
   const [isUpdate] = useState(target !== undefined);
-  const createMutate = useMutate({ key: 'users', action: createUser });
-  const updateMutate = useMutate({ key: 'users', action: updateUser });
-  const refObj: RefType = {
-    idInput: useRef<HTMLInputElement>(null),
-    passwordInput: useRef<HTMLInputElement>(null),
-    roleInput: useRef<HTMLSelectElement>(null),
-  };
+  const roleNameRef = useRef<HTMLSelectElement>(null);
 
-  const { idInput, passwordInput, roleInput } = refObj;
+  const [id, setId, isValidId, onChangeId] = useInput(true);
+  const [password, , isValidPassword, onChangePassword] = useInput(true);
 
-  const handleOnClick = (): void => {
-    if (validationCheck(refObj)) {
-      if (target === undefined)
-        createMutate.mutate(
-          {
-            username: idInput.current?.value,
-            password: passwordInput.current?.value,
-            roleName: roleInput.current?.value,
-          },
-          { onSuccess: close },
-        );
-      else {
-        updateMutate.mutate(
-          {
-            userId: target.userId,
-            password: '1234', // todo: (현재 필수값)password 수정 api 분리되면 삭제
-            roleName: roleInput.current?.value,
-          },
-          { onSuccess: close },
-        );
-      }
+  const handleOnClick = (): undefined => {
+    if (isValidId === false || roleNameRef.current?.value === '') return;
+    if (!isUpdate && isValidPassword === true) {
+      createMutate.mutate({
+        username: id,
+        password,
+        roleName: roleNameRef.current?.value,
+      });
+    } else {
+      updateMutate.mutate({
+        userId: target.userId,
+        password: '1234', // todo: (현재 필수값)password 수정 api 분리되면 삭제
+        roleName: roleNameRef.current?.value,
+      });
     }
   };
 
   useEffect(() => {
-    if (!isUpdate || idInput.current == null || roleInput.current == null) {
-      return;
-    }
-    const { username, roleName } = target;
-    idInput.current.value = username;
-    roleInput.current.value = roleName;
-  }, [idInput.current, passwordInput.current, roleInput.current]);
+    if (!isUpdate) return;
+    // modal 기본값 설정
+    setId(target.username);
+  }, []);
 
   return (
-    <Modal close={close} action={handleOnClick} isUpdate={isUpdate}>
-      <ModalInput title="ID" placeholder="ID를 입력하세요..." readonly={isUpdate} ref={idInput} />
-      {!isUpdate && <ModalInput title="비밀번호" placeholder="비밀번호를 입력하세요..." ref={passwordInput} />}
-      <SelectInput optionList={ROLES} title="권한" ref={roleInput} />
+    <Modal onClose={close} onSubmit={handleOnClick}>
+      {ModalBody({ isUpdate, id, onChangeId, isValidId, password, onChangePassword, isValidPassword, roleNameRef })}
     </Modal>
   );
 }

--- a/client/src/components/AuthModal.tsx
+++ b/client/src/components/AuthModal.tsx
@@ -9,6 +9,7 @@ import { createUser, updateUser } from '@utils/useAccounts';
 import useInput from '@hooks/useInput';
 import RequiredInput from './RequiredInput';
 import { checkLength, checkRequired } from '@utils/common';
+import { toast } from 'react-toastify';
 
 interface Props {
   close: () => void;
@@ -80,7 +81,10 @@ function AuthModal({ close, target }: Props): ReactElement {
   const [password, , errorPasswordMessage, onChangePassword] = useInput({ ...useInputParameter, title: '비밀번호' });
 
   const handleOnClick = (): undefined => {
-    if (errorIdMessage === '' || errorPasswordMessage === '' || roleNameRef.current?.value === '') return;
+    if (errorIdMessage !== '' || errorPasswordMessage !== '' || roleNameRef.current?.value === '') {
+      toast.error('입력값을 확인하세요');
+      return;
+    }
 
     if (!isUpdate) {
       createMutate.mutate({

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -1,0 +1,62 @@
+import { ReactElement } from 'react';
+import styled from 'styled-components';
+import { ReactProps, StyledProps } from '@type/props';
+import ModalButton from './ModalButton';
+
+interface Props {
+  isUpdate: boolean;
+  close: () => void;
+  action: () => void;
+}
+
+const Wrapper = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  z-index: 10000;
+`;
+
+const ModalWrapper = styled.div`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: max-content;
+  height: max-content;
+  max-height: 600px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding-inline: 50px;
+  padding-block: 30px;
+  border-radius: 10px;
+  background-color: var(--color-white);
+  box-shadow: 1px 1px 4px 4px var(--color-black);
+  z-index: 20000;
+`;
+
+const OverLay = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-black);
+  opacity: 0.8;
+  z-index: 10000;
+`;
+
+const Modal = ({ children, ...props }: StyledProps<ReactProps<Props>>): ReactElement => {
+  return (
+    <Wrapper>
+      <OverLay onClick={props.close} />
+      <ModalWrapper>
+        {children}
+        <ModalButton onCancel={props.close} action={props.action} title={props.isUpdate ? '수정하기' : '추가하기'} />
+      </ModalWrapper>
+    </Wrapper>
+  );
+};
+
+export default Modal;

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -1,13 +1,9 @@
 import { ReactElement } from 'react';
 import styled from 'styled-components';
-import { ReactProps, StyledProps } from '@type/props';
-import ModalButton from './ModalButton';
 
-interface Props {
-  isUpdate: boolean;
-  close: () => void;
-  action: () => void;
-}
+import ModalButton from './ModalButton';
+import { ModalType } from '@type/modal.type';
+import { ReactProps, StyledProps } from '@type/props';
 
 const Wrapper = styled.div`
   position: fixed;
@@ -47,13 +43,13 @@ const OverLay = styled.div`
   z-index: 10000;
 `;
 
-const Modal = ({ children, ...props }: StyledProps<ReactProps<Props>>): ReactElement => {
+const Modal = ({ onClose, onSubmit, children }: StyledProps<ReactProps<ModalType>>): ReactElement => {
   return (
     <Wrapper>
-      <OverLay onClick={props.close} />
+      <OverLay onClick={onClose} />
       <ModalWrapper>
         {children}
-        <ModalButton onCancel={props.close} action={props.action} title={props.isUpdate ? '수정하기' : '추가하기'} />
+        <ModalButton onCancel={onClose} action={onSubmit} />
       </ModalWrapper>
     </Wrapper>
   );

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -25,7 +25,7 @@ const ModalWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 20px;
+  gap: 25px;
   padding-inline: 50px;
   padding-block: 30px;
   border-radius: 10px;

--- a/client/src/components/ModalButton.tsx
+++ b/client/src/components/ModalButton.tsx
@@ -6,7 +6,6 @@ import TextButton from './TextButton';
 
 const ExitButton = styled(TextButton)`
   cursor: pointer;
-  margin-top: 20px;
   font-size: 18px;
   font-weight: 500;
   border: none;
@@ -15,7 +14,6 @@ const ExitButton = styled(TextButton)`
 
 const ConfirmButton = styled(TextButton)`
   cursor: pointer;
-  margin-top: 20px;
   font-size: 18px;
   font-weight: 500;
   border: none;

--- a/client/src/components/ModalButton.tsx
+++ b/client/src/components/ModalButton.tsx
@@ -30,11 +30,11 @@ interface Props {
   title?: string;
 }
 
-function ModalButton({ action, onCancel, title }: Props): ReactElement {
+function ModalButton({ action, onCancel, title = '확인' }: Props): ReactElement {
   return (
     <Wrapper>
       <ConfirmButton onClick={action}>{title}</ConfirmButton>
-      <ExitButton color={'--color-red'} onClick={onCancel}>
+      <ExitButton color="--color-red" onClick={onCancel}>
         돌아가기
       </ExitButton>
     </Wrapper>

--- a/client/src/components/RequiredInput.tsx
+++ b/client/src/components/RequiredInput.tsx
@@ -1,0 +1,85 @@
+import { ReactElement } from 'react';
+import styled from 'styled-components';
+import Text from './Text';
+
+interface Props {
+  value?: string;
+  onChange?: any;
+  title?: string;
+  isValid?: boolean;
+  readonly?: boolean;
+  color?: string;
+  backgroundColor?: string;
+  size?: number;
+  width?: number;
+  placeholder?: string;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const TextWrapper = styled.div<Props>`
+  position: relative;
+  display: flex;
+  gap: 20px;
+  justify-content: left;
+  align-items: center;
+  padding-inline: 16px;
+  padding-block: 12px;
+  border-radius: 10px;
+  background-color: var(${({ backgroundColor }) => backgroundColor ?? '--color-white'});
+  border: 2px solid var(${({ color }) => color ?? '--color-dark-gray'});
+  width: max-content;
+`;
+
+const StyledInput = styled.input<Props>`
+  font-family: 'Noto Sans KR';
+  color: var(${({ color }) => color ?? '--color-dark-gray'});
+  font-weight: 500;
+  font-size: ${({ size }) => size ?? 15}px;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  width: ${({ width }) => (width !== undefined ? `${width}px` : 'max-content')};
+
+  &:read-only {
+    color: var(--color-gray);
+  }
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+function RequiredInput({
+  value,
+  onChange,
+  title = '',
+  isValid = true,
+  readonly = false,
+  ...props
+}: Props): ReactElement {
+  return (
+    <Wrapper>
+      <TitleWrapper>
+        <Text size={20} weight={700}>
+          {title}
+        </Text>
+        {!isValid && (
+          <Text color="--color-red" weight={500} size={12}>
+            {`${title}는 필수값입니다`}
+          </Text>
+        )}
+      </TitleWrapper>
+      <TextWrapper {...props}>
+        <StyledInput value={value} onChange={onChange} placeholder={`${title}을 입력하세요...`} readOnly={readonly} />
+      </TextWrapper>
+    </Wrapper>
+  );
+}
+export default RequiredInput;

--- a/client/src/components/RequiredInput.tsx
+++ b/client/src/components/RequiredInput.tsx
@@ -6,7 +6,7 @@ interface Props {
   value?: string;
   onChange?: any;
   title?: string;
-  isValid?: boolean;
+  errorMessage?: string | undefined;
   readonly?: boolean;
   color?: string;
   backgroundColor?: string;
@@ -15,10 +15,20 @@ interface Props {
   placeholder?: string;
 }
 
-const Wrapper = styled.div`
+const InputWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 5px;
+  width: 100%;
+  align-items: flex-end;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  width: 100%;
+  align-items: center;
 `;
 
 const TextWrapper = styled.div<Props>`
@@ -50,36 +60,36 @@ const StyledInput = styled.input<Props>`
   }
 `;
 
-const TitleWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+const Blank = styled.div`
+  height: 12px;
 `;
 
 function RequiredInput({
   value,
   onChange,
   title = '',
-  isValid = true,
+  errorMessage = '',
   readonly = false,
   ...props
 }: Props): ReactElement {
   return (
-    <Wrapper>
-      <TitleWrapper>
+    <InputWrapper>
+      <Wrapper>
         <Text size={20} weight={700}>
           {title}
         </Text>
-        {!isValid && (
-          <Text color="--color-red" weight={500} size={12}>
-            {`${title}는 필수값입니다`}
-          </Text>
-        )}
-      </TitleWrapper>
-      <TextWrapper {...props}>
-        <StyledInput value={value} onChange={onChange} placeholder={`${title}을 입력하세요...`} readOnly={readonly} />
-      </TextWrapper>
-    </Wrapper>
+        <TextWrapper {...props}>
+          <StyledInput value={value} onChange={onChange} placeholder={`${title}을 입력하세요...`} readOnly={readonly} />
+        </TextWrapper>
+      </Wrapper>
+      {errorMessage !== '' ? (
+        <Text color="--color-red" weight={500} size={12}>
+          {errorMessage}
+        </Text>
+      ) : (
+        <Blank />
+      )}
+    </InputWrapper>
   );
 }
 export default RequiredInput;

--- a/client/src/components/Select.tsx
+++ b/client/src/components/Select.tsx
@@ -22,14 +22,14 @@ const Wrapper = styled.select<Props>`
   border-radius: 10px;
   background-color: var(${({ backgroundColor }) => backgroundColor ?? '--color-white'});
   border: 2px solid var(${({ color }) => color ?? '--color-dark-gray'});
-  width: 200px;
+  width: 206px;
 
   option {
     font-family: 'Noto Sans KR';
     color: var(${({ color }) => color ?? '--color-dark-gray'});
     font-weight: 500;
     font-size: ${({ size }) => size ?? 15}px;
-    width: ${({ width }) => (width !== undefined ? `${width}px` : '200px')};
+    width: ${({ width }) => (width !== undefined ? `${width}px` : '206px')};
   }
 `;
 

--- a/client/src/components/SelectInput.tsx
+++ b/client/src/components/SelectInput.tsx
@@ -12,9 +12,10 @@ interface Props {
 }
 const Wrapper = styled.div`
   display: flex;
-  flex-direction: column;
-  justify-content: left;
+  justify-content: space-between;
+  align-items: center;
   gap: 10px;
+  width: 100%;
 `;
 
 function SelectInput({ optionList, title }: Props, ref: Ref<HTMLSelectElement>): ReactElement {

--- a/client/src/hooks/useInput.ts
+++ b/client/src/hooks/useInput.ts
@@ -1,0 +1,34 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+
+const INVALID = [null, undefined, ''];
+
+const useInput = (required = false, regex = undefined): any[] => {
+  const [value, setValue] = useState('');
+  const [isValid, setIsValid] = useState(true);
+
+  useEffect(() => {
+    if (required && value === '') {
+      setIsValid(false);
+    }
+    if (!required || value !== '') {
+      setIsValid(true);
+    }
+  }, [value]);
+
+  const handleOnChange = ({ target }: ChangeEvent<HTMLInputElement>): void => {
+    setValue(target.value);
+
+    if (regex !== undefined && target.value.match(regex) === null) {
+      setIsValid(false);
+      return;
+    }
+    if (required && INVALID.includes(target.value)) {
+      setIsValid(false);
+      return;
+    }
+    setIsValid(true);
+  };
+
+  return [value, setValue, isValid, handleOnChange];
+};
+export default useInput;

--- a/client/src/hooks/useInput.ts
+++ b/client/src/hooks/useInput.ts
@@ -1,34 +1,31 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 
-const INVALID = [null, undefined, ''];
+interface InputType {
+  title: string;
+  max?: number;
+  min?: number;
+  validationCheck?: Array<(title: string, target: string, max: number, min: number) => string>;
+}
 
-const useInput = (required = false, regex = undefined): any[] => {
+const useInput = ({ title, min = 1, max = 250, ...props }: InputType): any[] => {
   const [value, setValue] = useState('');
-  const [isValid, setIsValid] = useState(true);
+  const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
-    if (required && value === '') {
-      setIsValid(false);
-    }
-    if (!required || value !== '') {
-      setIsValid(true);
-    }
+    if (props.validationCheck === undefined) return;
+
+    const result = props.validationCheck
+      .map((checkFunction) => checkFunction(title, value, min, max))
+      .filter((errorMsg) => errorMsg !== '');
+
+    setErrorMessage(result[0]);
   }, [value]);
 
   const handleOnChange = ({ target }: ChangeEvent<HTMLInputElement>): void => {
     setValue(target.value);
-
-    if (regex !== undefined && target.value.match(regex) === null) {
-      setIsValid(false);
-      return;
-    }
-    if (required && INVALID.includes(target.value)) {
-      setIsValid(false);
-      return;
-    }
-    setIsValid(true);
   };
 
-  return [value, setValue, isValid, handleOnChange];
+  return [value, setValue, errorMessage, handleOnChange];
 };
+
 export default useInput;

--- a/client/src/hooks/useInput.ts
+++ b/client/src/hooks/useInput.ts
@@ -7,14 +7,12 @@ interface InputType {
   validationCheck?: Array<(title: string, target: string, max: number, min: number) => string>;
 }
 
-const useInput = ({ title, min = 1, max = 250, ...props }: InputType): any[] => {
+const useInput = ({ title, min = 1, max = 250, validationCheck = [] }: InputType): any[] => {
   const [value, setValue] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
-    if (props.validationCheck === undefined) return;
-
-    const result = props.validationCheck
+    const result = validationCheck
       .map((checkFunction) => checkFunction(title, value, min, max))
       .filter((errorMsg) => errorMsg !== '');
 

--- a/client/src/hooks/useMutate.ts
+++ b/client/src/hooks/useMutate.ts
@@ -12,23 +12,22 @@ interface MutationParameterType {
   action: (parameter: any) => Promise<AxiosResponse<any>>;
   key?: string;
   callback?: (parameter: any) => Promise<void>;
+  onSuccess?: () => void;
 }
 
 const useMutate = (parameter: MutationParameterType): MutationType => {
   const queryClient = useQueryClient();
-
-  const invalidate = async (key: string): Promise<void> => {
-    await queryClient.invalidateQueries(key);
-  };
 
   const { mutate, mutateAsync } = useMutation(parameter.action, {
     onSuccess: async ({ data }) => {
       if (parameter.callback !== undefined) await parameter.callback(data);
 
       if (parameter.key !== undefined) {
-        await invalidate(parameter.key);
+        await queryClient.invalidateQueries(parameter.key);
         toast('완료되었습니다.');
       }
+
+      if (parameter.onSuccess !== undefined) parameter.onSuccess();
     },
     onError: handleOnError,
   });

--- a/client/src/types/modal.type.ts
+++ b/client/src/types/modal.type.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react';
+
+export interface ModalType {
+  onSubmit: () => void;
+  onClose: () => void;
+  element?: ReactNode;
+}

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -16,3 +16,11 @@ export const handleOnError = ({ response }: { response: ErrorResponse }): void =
   const { status } = response;
   toast.error(ERROR_MESSAGE[status as keyof typeof ERROR_MESSAGE]);
 };
+
+export const checkRequired = (title: string, target: string): string => {
+  return target === '' ? `${title}는(은) 필수값입니다.` : '';
+};
+
+export const checkLength = (title: string, target: string, min: number, max: number): string => {
+  return target.length > max || target.length < min ? `${title}는(은) ${min}자 ~ ${max}자여야 합니다` : '';
+};


### PR DESCRIPTION
## 개요

## 세부 내용
- modal component 분리
- Required Input에 대한 처리 추가

## 공유
- account update 시, password까지 필수값이기 때문에 일단 임의의 값 '1234' 넣어놓음
    - 추후에 Account Update API 분리 시 수정 필요
```tsx
      updateMutate.mutate({
        userId: target.userId,
        password: '1234', // todo: (현재 필수값)password 수정 api 분리되면 삭제
        roleName: roleNameRef.current?.value,
      });
```

- input validation check하는 기능도 수정함
    - check 함수 받아서 사용하는 형식으로 조정
    
<img width="300" alt="스크린샷 2023-02-09 오후 5 43 10" src="https://user-images.githubusercontent.com/39304306/217761044-eb097ede-dd2f-4222-8f97-4d38e37fbacd.png">

## 관련 이슈

- #20 