### PR TITLE
[FEAT] account page modal 연동

### DIFF
--- a/client/src/components/AuthModal.tsx
+++ b/client/src/components/AuthModal.tsx
@@ -43,7 +43,7 @@ function ModalBody({
   target,
 }: ModalBodyProps): ReactElement {
   useEffect(() => {
-    if (roleNameRef.current != null) roleNameRef.current.value = target.roleName;
+    if (roleNameRef.current != null && target !== undefined) roleNameRef.current.value = target.roleName;
   }, [roleNameRef.current]);
 
   return (

--- a/client/src/components/AuthModal.tsx
+++ b/client/src/components/AuthModal.tsx
@@ -10,6 +10,7 @@ import useInput from '@hooks/useInput';
 import RequiredInput from './RequiredInput';
 import { checkLength, checkEmpty, checkRequired } from '@utils/common';
 import { toast } from 'react-toastify';
+import { AccountDtoType } from '@type/dto.type';
 
 interface Props {
   close: () => void;
@@ -25,6 +26,7 @@ interface ModalBodyProps {
   onChangePassword: Function;
   errorPasswordMessage: string | undefined;
   roleNameRef: RefObject<HTMLSelectElement>;
+  target: AccountDtoType;
 }
 
 const ROLES = ['ROLE_ADMIN', 'ROLE_USER'];
@@ -38,7 +40,12 @@ function ModalBody({
   onChangePassword,
   errorPasswordMessage,
   roleNameRef,
+  target,
 }: ModalBodyProps): ReactElement {
+  useEffect(() => {
+    if (roleNameRef.current != null) roleNameRef.current.value = target.roleName;
+  }, [roleNameRef.current]);
+
   return (
     <>
       <Text size={24}>{isUpdate ? '계정 수정' : '계정 생성'}</Text>
@@ -81,7 +88,11 @@ function AuthModal({ close, target }: Props): ReactElement {
   const [password, , errorPasswordMessage, onChangePassword] = useInput({ ...useInputParameter, title: '비밀번호' });
 
   const handleOnClick = (): undefined => {
-    if (!checkEmpty(errorIdMessage) || !checkEmpty(errorPasswordMessage) || checkEmpty(roleNameRef.current?.value)) {
+    if (
+      !checkEmpty(errorIdMessage) ||
+      (!checkEmpty(errorPasswordMessage) && !isUpdate) ||
+      checkEmpty(roleNameRef.current?.value)
+    ) {
       toast.error('입력값을 확인하세요');
       return;
     }
@@ -118,6 +129,7 @@ function AuthModal({ close, target }: Props): ReactElement {
         onChangePassword,
         errorPasswordMessage,
         roleNameRef,
+        target,
       })}
     </Modal>
   );

--- a/client/src/components/Tables/AccountTable.tsx
+++ b/client/src/components/Tables/AccountTable.tsx
@@ -13,10 +13,10 @@ import { useConfirm } from '@utils/common';
 
 interface ParameterType {
   rows: AccountDtoType[];
-  updateAction: (row: AccountDtoType) => void;
+  onUpdate: (row: AccountDtoType) => void;
 }
 
-const getAccountTableFormat = (updateAction: (row: AccountDtoType) => void): Array<TableColumn<AccountDtoType>> => {
+const getAccountTableFormat = (onUpdate: (row: AccountDtoType) => void): Array<TableColumn<AccountDtoType>> => {
   return [
     { key: 'No.', component: ({ i }) => <NumberColumn>{i + 1}</NumberColumn> },
     { key: 'ID', component: ({ row }) => <TextColumn>{row.username}</TextColumn> },
@@ -35,7 +35,7 @@ const getAccountTableFormat = (updateAction: (row: AccountDtoType) => void): Arr
         <ButtonColumn
           color="--color-blue"
           onClick={() => {
-            updateAction(row);
+            onUpdate(row);
           }}
         >
           수정
@@ -67,6 +67,6 @@ const getAccountTableFormat = (updateAction: (row: AccountDtoType) => void): Arr
   ];
 };
 
-export default function AccountTable({ rows, updateAction }: ParameterType): ReactElement {
-  return <Table rows={rows} format={getAccountTableFormat(updateAction)} />;
+export default function AccountTable({ rows, onUpdate }: ParameterType): ReactElement {
+  return <Table rows={rows} format={getAccountTableFormat(onUpdate)} />;
 }

--- a/client/src/components/Tables/AccountTable.tsx
+++ b/client/src/components/Tables/AccountTable.tsx
@@ -9,47 +9,64 @@ import { deleteUser } from '@utils/useAccounts';
 
 import Table from '@components/Tables/Table';
 import { AccountDtoType } from '@type/dto.type';
+import { useConfirm } from '@utils/common';
 
-const accountTableFormat: Array<TableColumn<AccountDtoType>> = [
-  { key: 'No.', component: ({ i }) => <NumberColumn>{i + 1}</NumberColumn> },
-  { key: 'ID', component: ({ row }) => <TextColumn>{row.username}</TextColumn> },
-  { key: '역할', component: ({ row }) => <TextColumn>{row.roleName}</TextColumn> },
-  {
-    key: '생성일',
-    component: ({ row }) => <TextColumn>{row.createdAt.toLocaleDateString()}</TextColumn>,
-  },
-  {
-    key: '수정일',
-    component: ({ row }) => <TextColumn>{row.updatedAt.toLocaleDateString()}</TextColumn>,
-  },
-  {
-    key: '수정',
-    component: ({ row }) => (
-      <ButtonColumn
-        color="--color-blue"
-        onClick={() => {
-          console.log(`update ${row.username}`);
-        }}
-      >
-        수정
-      </ButtonColumn>
-    ),
-  },
-  {
-    key: '삭제',
-    component: ({ row }) => (
-      <ButtonColumn
-        color="--color-red"
-        onClick={() => {
-          useMutate({ key: 'users', action: deleteUser }).mutate(row.userId);
-        }}
-      >
-        삭제
-      </ButtonColumn>
-    ),
-  },
-];
+interface ParameterType {
+  rows: AccountDtoType[];
+  updateAction: (row: AccountDtoType) => void;
+}
 
-export default function AccountTable({ rows }: { rows: AccountDtoType[] }): ReactElement {
-  return <Table rows={rows} format={accountTableFormat} />;
+const getAccountTableFormat = (updateAction: (row: AccountDtoType) => void): Array<TableColumn<AccountDtoType>> => {
+  return [
+    { key: 'No.', component: ({ i }) => <NumberColumn>{i + 1}</NumberColumn> },
+    { key: 'ID', component: ({ row }) => <TextColumn>{row.username}</TextColumn> },
+    { key: '역할', component: ({ row }) => <TextColumn>{row.roleName}</TextColumn> },
+    {
+      key: '생성일',
+      component: ({ row }) => <TextColumn>{row.createdAt.toLocaleDateString()}</TextColumn>,
+    },
+    {
+      key: '수정일',
+      component: ({ row }) => <TextColumn>{row.updatedAt.toLocaleDateString()}</TextColumn>,
+    },
+    {
+      key: '수정',
+      component: ({ row }) => (
+        <ButtonColumn
+          color="--color-blue"
+          onClick={() => {
+            updateAction(row);
+          }}
+        >
+          수정
+        </ButtonColumn>
+      ),
+    },
+    {
+      key: '삭제',
+      component: ({ row }) => {
+        const { mutate } = useMutate({ key: 'users', action: deleteUser });
+
+        return (
+          <ButtonColumn
+            color="--color-red"
+            onClick={() => {
+              useConfirm({
+                message: '삭제하시겠습니까?',
+                onConfirm: () => {
+                  mutate(row.userId);
+                },
+              });
+            }}
+          >
+            삭제
+          </ButtonColumn>
+        );
+      },
+    },
+  ];
+};
+
+export default function AccountTable({ rows, updateAction }: ParameterType): ReactElement {
+  return <Table rows={rows} format={getAccountTableFormat(updateAction)} />;
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter } from 'react-router-dom';
@@ -8,14 +8,22 @@ import App from './App';
 import './index.css';
 import 'react-toastify/dist/ReactToastify.css';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+    },
+  },
+});
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <ToastContainer autoClose={800} />
-        <App />
+        <Suspense fallback={<div>loading</div>}>
+          <ToastContainer autoClose={800} />
+          <App />
+        </Suspense>
       </QueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/client/src/pages/AccountsPage.tsx
+++ b/client/src/pages/AccountsPage.tsx
@@ -1,18 +1,44 @@
 import AccountTable from '@components/Tables/AccountTable';
-import { ReactElement } from 'react';
+import { ReactElement, useState } from 'react';
 import { useQuery } from 'react-query';
 import { handleOnError } from '@utils/common';
 import { getUsers, transformData } from '@utils/useAccounts';
+import SideButton from '@components/SideButton';
+import AuthModal from '@components/AuthModal';
+import { AccountDtoType } from '@type/dto.type';
 
 function AccountsPage(): ReactElement {
-  const { data, isLoading } = useQuery('users', getUsers, {
+  const [hasModal, setHasModal] = useState(false);
+  const [target, setTarget] = useState<AccountDtoType>(); // 수정 시 모달에 표현돼야 하는 데이터
+
+  const { data } = useQuery('users', getUsers, {
     onError: handleOnError,
     select: (data) => transformData(data),
   });
 
+  const openEditModal = (row: AccountDtoType): void => {
+    setHasModal(true);
+    setTarget(row);
+  };
+
+  const openModal = (): void => {
+    setHasModal(true);
+  };
+
+  const closeModal = (): void => {
+    setHasModal(false);
+    setTarget(undefined);
+  };
+
   return (
     <div>
-      {isLoading ? <div>loading</div> : data !== undefined ? <AccountTable rows={data} /> : <div>dataundefined</div>}
+      {data !== undefined && (
+        <div>
+          <AccountTable rows={data} updateAction={openEditModal} />
+          <SideButton action={openModal} />
+          {hasModal && <AuthModal close={closeModal} target={target} />}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/pages/AccountsPage.tsx
+++ b/client/src/pages/AccountsPage.tsx
@@ -21,7 +21,7 @@ function AccountsPage(): ReactElement {
     setTarget(row);
   };
 
-  const openModal = (): void => {
+  const openCreateModal = (): void => {
     setHasModal(true);
   };
 
@@ -35,7 +35,7 @@ function AccountsPage(): ReactElement {
       {data !== undefined && (
         <div>
           <AccountTable rows={data} onUpdate={openEditModal} />
-          <SideButton action={openModal} />
+          <SideButton action={openCreateModal} />
           {hasModal && <AuthModal close={closeModal} target={target} />}
         </div>
       )}

--- a/client/src/pages/AccountsPage.tsx
+++ b/client/src/pages/AccountsPage.tsx
@@ -34,7 +34,7 @@ function AccountsPage(): ReactElement {
     <div>
       {data !== undefined && (
         <div>
-          <AccountTable rows={data} updateAction={openEditModal} />
+          <AccountTable rows={data} onUpdate={openEditModal} />
           <SideButton action={openModal} />
           {hasModal && <AuthModal close={closeModal} target={target} />}
         </div>

--- a/client/src/utils/useAccounts.ts
+++ b/client/src/utils/useAccounts.ts
@@ -34,7 +34,7 @@ export const updateUser = async (parameter: AccountType): Promise<AxiosResponse<
   return await axios.put<AccountResponse<AccountType>>('/users', parameter);
 };
 
-export const deleteUser = async (id: string): Promise<AxiosResponse<AccountResponse<AccountType>>> => {
+export const deleteUser = async (id: number): Promise<AxiosResponse<AccountResponse<AccountType>>> => {
   return await axios.delete<AccountResponse<AccountType>>(`/users/${id === undefined ? '' : id.toString()}`);
 };
 


### PR DESCRIPTION
## 개요
- Account Page Update, delete 연동(table)

## 세부 내용
- queryclient Suspense 일반화
- update modal validation check 개선
- delete 시 confirm 추가

## 공유

### 1. Table format을 함수로 받아옴
- updateAction을 주입받기 위해 배열이 아닌 `getAccountTableFormat()`으로 format을 받아옴
- 
```tsx
export default function AccountTable({ rows, updateAction }: ParameterType): ReactElement {
  return <Table rows={rows} format={getAccountTableFormat(updateAction)} />;
}
```
### 2. row 수정
- `getAccountTableFormat` 내부에 아래와 같이 onclick event를 추가함
```tsx
{
      key: '수정',
      component: ({ row }) => (
        <ButtonColumn
          color="--color-blue"
          onClick={() => {
            updateAction(row);
          }}
        >
          수정
        </ButtonColumn>
      ),
    },
 ```
### 3. row 삭제
- onclick이 아니라, component return 문 상단에 useMutate를 선언해서 `invalid hook calls` 를 막을 수 있음
```tsx
    {
      key: '삭제',
      component: ({ row }) => {
        const { mutate } = useMutate({ key: 'users', action: deleteUser }); // 여기에 선언

        return (
          <ButtonColumn
            color="--color-red"
            onClick={() => {
              useConfirm({
                message: '삭제하시겠습니까?',
                onConfirm: () => {
                  mutate(row.userId);
                },
              });
            }}
          >
            삭제
          </ButtonColumn>
        );
      },
    },
```
### 4. react query Suspense default 설정
- App 상단에 Suspense로 loading을 넣어놔서 페이지별로 데이터 로딩 시의 화면을 별도로 선언할 필요가 없음
- 그런데 ErrorBoundary는 안해서 이 부분 고민 필요
```tsx
        <Suspense fallback={<div>loading</div>}>
          <ToastContainer autoClose={800} />
          <App />
        </Suspense>
```
## 관련 이슈

- #36 