### PR TITLE
Fix: parts page api가 제대로 동작하지 않음

### DIFF
--- a/client/src/components/Tables/PartTable.tsx
+++ b/client/src/components/Tables/PartTable.tsx
@@ -58,7 +58,7 @@ const partTableFormat = (onUpdate: (row: PartDtoType) => void): Array<TableColum
   {
     key: '삭제',
     component: ({ row }) => {
-      const { mutate } = useMutate({ key: 'product', action: deletePart(row.partId) });
+      const { mutate } = useMutate({ key: 'part', action: deletePart(row.partId) });
       return (
         <ButtonColumn
           color="--color-red"

--- a/client/src/fetches/part.ts
+++ b/client/src/fetches/part.ts
@@ -5,7 +5,7 @@ import { PartDtoType } from '@type/dto.type';
 
 export const getPart = (partName: string) => {
   return async (): Promise<AxiosResponse<ApiResponse<ApiData<PartDbType[]>>, any>> => {
-    return await axios.get<ApiResponse<ApiData<PartDbType[]>>>(`/parts?part-name=${partName}`);
+    return await axios.get<ApiResponse<ApiData<PartDbType[]>>>('/parts?');
   };
 };
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -35,6 +35,10 @@ export default defineConfig({
         target: 'http://146.56.168.39/api/v1/',
         changeOrigin: true,
       },
+      '/parts': {
+        target: 'http://146.56.168.39/api/v1/',
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## 개요
- parts page api가 제대로 동작하지 않는 문제 해결

## 세부 내용
- Vite 서버 프록시 설정 추가 (`/parts`)
- deletePart mutation의 키워드가 `product` 로 설정되어있던 것을 `part`로 수정
- getPart 요청이 현재 `/parts?part-name=`을 null 검색으로 취급하지 않기 때문에 임시로 `/parts?`로만 요청을 쏘도록 임시 처리.
- 
## 공유
  
## 관련 이슈
- #43 